### PR TITLE
Cache bundle downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,19 @@ ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 clean:
 	rm -rf src/ dist/
 
+console:
+	@echo "Console Help"
+	@echo
+	@echo "Specify a verion to install:"
+	@echo "    echo 5.2.1 > /env/JEMALLOC_VERSION"
+	@echo
+	@echo "To vendor jemalloc:"
+	@echo "    bin/compile /app/ /cache/ /env/"
+	@echo
+
+	@docker run --rm -ti -v $(shell pwd):/buildpack -e "STACK=heroku-18" -w /buildpack heroku/heroku:18-build \
+		bash -c 'mkdir /app /cache /env; exec bash'
+
 # Download missing source archives to ./src/
 src/jemalloc-%.tar.bz2:
 	mkdir -p $$(dirname $@)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ heroku buildpacks:add --index 1 https://github.com/gaffneyc/heroku-buildpack-jem
 git push heroku master
 ```
 
+## Made possible by Dead Man's Snitch
+
+Continued development and support of the jemalloc buildpack is sponsored by
+[Dead Man's Snitch](https://deadmanssnitch.com).
+
+Ever been surprised that a critical recurring job was silently failing to run?
+Whether it's backups, cache clearing, sending invoices, or whatever your
+application depends on, Dead Man's Snitch makes it easy to
+[monitor heroku scheduler](https://deadmanssnitch.com/docs/heroku) tasks or to add
+[cron job monitoring](https://deadmanssnitch.com/docs/cron-job-monitoring) to
+your other services.
+
+Get started for free today with [Dead Man's Snitch on Heroku](https://elements.heroku.com/addons/deadmanssnitch)
+
 ## Usage
 
 ### Recommended
@@ -83,17 +97,6 @@ heroku config:set JEMALLOC_VERSION=3.6.0
 
 The complete and most up to date list of supported versions and stacks is
 available on the [releases page.](https://github.com/gaffneyc/heroku-buildpack-jemalloc/releases)
-
-## Thanks
-
-Continued development of the jemalloc buildpack is sponsored by [Dead Man's Snitch](https://deadmanssnitch.com).
-Ever been surprised that a critical scheduled task was silently failing to
-run? Whether it's backups, cache clearing, or sending invoices, Dead Man's Snitch makes it easy to
-[monitor heroku scheduler](https://deadmanssnitch.com/docs/heroku) tasks or to add
-[cron job monitoring](https://deadmanssnitch.com/docs/cron-job-monitoring)
-to your other services.
-
-Get started for free today with [Dead Man's Snitch on Heroku](http://github.com/deadmanssnitch/heroku-buildpack-dms)
 
 ## Building
 

--- a/bin/compile
+++ b/bin/compile
@@ -15,16 +15,45 @@ if [ -f $ENV_DIR/JEMALLOC_VERSION ]; then
   version=$(cat $ENV_DIR/JEMALLOC_VERSION)
 fi
 
-url="https://github.com/gaffneyc/heroku-buildpack-jemalloc/releases/download/$STACK/jemalloc-$version.tar.bz2"
+# dest is the path in the application that jemalloc will be extracted to.
 dest="$BUILD_DIR/vendor/jemalloc"
 
-echo "-----> Vendoring jemalloc $version"
-echo "       Fetching $url"
+# bundle is the full path to the cached jemalloc binaries for this version.
+bundle=$CACHE_DIR/jemalloc/$version
+
+function download_jemalloc() {
+  url="https://github.com/gaffneyc/heroku-buildpack-jemalloc/releases/download/$STACK/jemalloc-$version.tar.bz2"
+
+  # Disable exit on command failure so we can provide better error messages
+  set +e
+
+  echo "       Fetching $url"
+  status=$(curl -sL -f  -w "%{http_code}" -o /tmp/jemalloc.tar.bz2 $url)
+
+  if [[ $status -ge 300 ]]; then
+    echo " !     jemalloc: Server returned HTTP $status"
+    exit 1
+  fi
+
+  # Reenable exit on failure
+  set -e
+
+  mkdir -p $bundle
+  tar -xj -f /tmp/jemalloc.tar.bz2 -C $bundle
+}
+
+echo "-----> jemalloc: Vendoring $version"
+
+# Check if this version of jemalloc is in the cache and download it if it
+# doesn't exist.
+if [[ ! -f $bundle ]]; then
+  download_jemalloc
+fi
 
 mkdir -p $dest
-curl -sL $url | tar -C $dest -xj
+cp -r $bundle -T $dest/
 
-echo "-----> Building runtime environment"
+echo "-----> jemalloc: Building runtime environment"
 mkdir -p $BUILD_DIR/.profile.d
 
 cat <<'EOF' > $BUILD_DIR/.profile.d/jemalloc.sh

--- a/bin/compile
+++ b/bin/compile
@@ -27,7 +27,7 @@ function download_jemalloc() {
   # Disable exit on command failure so we can provide better error messages
   set +e
 
-  echo "       Fetching $url"
+  echo "       jemalloc: Fetching $url"
   status=$(curl -sL -f  -w "%{http_code}" -o /tmp/jemalloc.tar.bz2 $url)
 
   if [[ $status -ge 300 ]]; then
@@ -46,7 +46,7 @@ echo "-----> jemalloc: Vendoring $version"
 
 # Check if this version of jemalloc is in the cache and download it if it
 # doesn't exist.
-if [[ ! -f $bundle ]]; then
+if [[ ! -d $bundle ]]; then
   download_jemalloc
 fi
 


### PR DESCRIPTION
GitHub's releases service recently had an issue where downloads were failing. This attempts to fix two main issues: resilience for deploys and improved error messages.

Using Heroku's cache we should only need to download each version once. This will allow deploys should GitHub have issues in the future.

Before this change, if there was an error downloading the bundle then the buildpack would fail with an error about bzip file formats. This now checks the http status code and prints a more useful error should it fail.

 Fixes #13