### PR TITLE
Check the dyno's STACK to download the correct version on stack change

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,23 @@ dest="$BUILD_DIR/vendor/jemalloc"
 # bundle is the full path to the cached jemalloc binaries for this version.
 bundle=$CACHE_DIR/jemalloc/$version
 
+# cached checks to see if there is a compatible version in the cache.
+function cached() {
+  # Returns false when there is no matching version in the cache.
+  if [[ ! -d $bundle ]]; then
+    return 1
+  fi
+
+  if [ -f "$bundle/.stack" ]; then
+    CACHED_STACK=$(cat $bundle/.stack)
+  fi
+
+  # True when the downloaded version in the cache is for the same stack as the
+  # compiling dyno. CACHED_STACK will be empty when the .stack file is missing
+  # which also forces a fresh download.
+  [[ $CACHED_STACK == $STACK ]]
+}
+
 function download_jemalloc() {
   url="https://github.com/gaffneyc/heroku-buildpack-jemalloc/releases/download/$STACK/jemalloc-$version.tar.bz2"
 
@@ -40,13 +57,17 @@ function download_jemalloc() {
 
   mkdir -p $bundle
   tar -xj -f /tmp/jemalloc.tar.bz2 -C $bundle
+
+  # Store the stack version (e.g. heroku-20) that was downloaded to force a
+  # redownload should the stack change.
+  echo "$STACK" > "$bundle/.stack"
 }
 
 echo "-----> jemalloc: Vendoring $version"
 
 # Check if this version of jemalloc is in the cache and download it if it
 # doesn't exist.
-if [[ ! -d $bundle ]]; then
+if ! cached; then
   download_jemalloc
 fi
 


### PR DESCRIPTION
As edmorley points out, there can be ABI changes between different
stacks which could cause issues. It is, after all, the reason that we
have a download specific to each stack.

This change adds a .stack file in the cached directory which we use to
track which version of the compiled binary was originally downloaded.
When that file is missing (i.e. for anyone already using the buildpack)
then we will force a download on the next deploy.

Fixes #19