### PR TITLE
Verify SHA256 of `jemalloc-$version.tar.bz2` to protect against supply chain attacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,8 +54,8 @@ function download_jemalloc() {
   fi
 
   # Check the SHA value to prevent supply chain attacks from replacing the jemalloc executable
-  cp "$BIN_DIR/sha/$STACK/jemalloc-$version.tar.bz2.sha" /tmp/jemalloc.tar.bz2.sha
-  (cd /tmp; sha1sum -c jemalloc.tar.bz2.sha)
+  cp "$BIN_DIR/sha256/$STACK/jemalloc-$version.tar.bz2.sha" /tmp/jemalloc.tar.bz2.sha
+  (cd /tmp; sha256sum -c jemalloc.tar.bz2.sha)
   if [ $? != 0 ]; then
     echo " !     jemalloc: Downloaded file failed SHA check"
     exit 1

--- a/bin/sha/heroku-20/jemalloc-3.6.0.tar.bz2.sha
+++ b/bin/sha/heroku-20/jemalloc-3.6.0.tar.bz2.sha
@@ -1,1 +1,0 @@
-65f053699fdb78ebb355db9c1c5c7e0a454d89d7  jemalloc.tar.bz2

--- a/bin/sha256/heroku-20/jemalloc-3.6.0.tar.bz2.sha
+++ b/bin/sha256/heroku-20/jemalloc-3.6.0.tar.bz2.sha
@@ -1,0 +1,1 @@
+85ee24912dd46d00107aecee0f65ece1b19828b4ef98ded9a6507e9297a311a4  jemalloc.tar.bz2


### PR DESCRIPTION
Hey there! Thanks so much for maintaining this repo – it's been a super useful buildpack for us at Splitwise, and seriously improved the memory usage of our Rails app.

This PR fixes a small-but-meaningful supply chain vulnerability for users of this buildpack. Right now this is only a proof-of-concept (SHAs for all the other stack + jemalloc version combos still need to be generated), but I wanted to open the PR at this point to ask for feedback.

### The vulnerable scenario
- Company A adds the `heroku-buildpack-jemalloc` buildpack to their Heroku app.
  - [Company A includes a commit SHA](https://devcenter.heroku.com/articles/buildpacks#buildpack-references) at the end of the buildpack URL, which lets them specify the exact commit being included in the buildpack. Even if an attacker takes over this repo and pushes a new malicious update to the buildpack code, the inclusion of the commit SHA helps prevent that attacker's buildpack code from making it into Company A's Heroku app.
- However, this buildpack ALSO [downloads](https://github.com/gaffneyc/heroku-buildpack-jemalloc/blob/8f21c9eecb6fe493d5269206ae41d1dbe485fdaf/bin/compile#L42) the file located at https://github.com/gaffneyc/heroku-buildpack-jemalloc/releases/download/$STACK/jemalloc-$version.tar.bz2
  - Unfortunately, this download is NOT verified – if an attacker gained access to this repo, they could delete an existing release and replace it with malicious code.

In practice, the [caching check](https://github.com/gaffneyc/heroku-buildpack-jemalloc/blob/8f21c9eecb6fe493d5269206ae41d1dbe485fdaf/bin/compile#L70) in the buildpack helps to mitigate this vulnerability somewhat, but in any scenario where the buildpack actually downloads the file (when first deploying a new app; after clearing the Heroku build cache; after changing the Heroku stack version or jemalloc version), the Heroku app is vulnerable. Thus, if this GitHub repo were ever to be compromised in some way, users of this buildpack would not have a way to guard themselves against downloading and running untrusted code.

### Remediation
A straightforward way to fix this is to verify the SHA256 of `jemalloc-$version.tar.bz2`, similar to how including a SHA in the buildpack URL allows an app to verify the code of the buildpack itself. This would mean that when new releases of `jemalloc-$version.tar.bz2` are added, the buildpack repo would also need to be updated to include SHA256 files for those releases. Thus, if a user of the buildpack chooses to lock the buildpack to a certain Git SHA, they have effectively protected themself from the supply chain attack described above.

—

Again, thanks so much for your work on this buildpack! As I mentioned, currently this PR only includes a SHA256 for a single Heroku stack + jemalloc version combo, but if this fix makes sense to the maintainer, then it should be straightforward to extend this solution to all existing version combos.