### PR TITLE
Retry transient download failures and check curl's exit code

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,10 +45,19 @@ function download() {
   set +e
 
   echo "       jemalloc: Downloading $url"
-  status=$(curl -sL -f  -w "%{http_code}" -o /tmp/jemalloc.tar.bz2 $url)
 
-  if [[ $status -ge 300 ]]; then
-    echo " !     jemalloc: Server returned HTTP $status"
+  # Retry transient failures. GitHub occasionally answers a release download
+  # with a 5xx or drops the connection, and without --retry that single blip
+  # fails the whole build — on a cold cache there is nothing to fall back to.
+  status=$(curl -sL -f --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors \
+    -w "%{http_code}" -o /tmp/jemalloc.tar.bz2 $url)
+
+  # A connection that never completed reports HTTP 000, which is below the 300
+  # threshold, so the curl exit code has to be checked alongside the status.
+  curl_status=$?
+
+  if [[ $curl_status -ne 0 || $status -ge 300 ]]; then
+    echo " !     jemalloc: Download failed after retries (curl exit $curl_status, HTTP $status)"
     exit 1
   fi
 


### PR DESCRIPTION
Two related robustness fixes to the download step.

### Retry transient failures

GitHub occasionally answers a release download with a 5xx or drops the connection. With no retry, a single blip fails the whole build, and on a cold cache there is nothing to fall back to — a Heroku review app is a brand-new app every time, so it always starts cold. This adds:

```
--retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors
```

### Check curl's exit code, not just the HTTP status

This one is subtle. When `-f` exhausts its retries, `-w "%{http_code}"` reports `000`, not the status that caused the failure. Since `000` is below the `300` threshold, the existing check does not fire, and a failed download falls through to the checksum step — so a network failure gets reported as a corrupt or substituted archive, which sends you looking in the wrong place.

Measured against live endpoints, before this change:

| case | curl exit | reported HTTP | `[[ $status -ge 300 ]]` fires |
| --- | --- | --- | --- |
| retried-out 503 | 52 | `000` | no |
| connection refused | 7 | `000` | no |
| real 5.3.0 asset | 0 | `200` | no (correct) |

Checking `$?` alongside the status catches both failure cases and reports them as what they are:

```
 !     jemalloc: Download failed after retries (curl exit 52, HTTP 000)
```

The success path is unchanged: the 5.3.0 asset still downloads and matches the checksum in the table (`2db82d1e…`).
